### PR TITLE
PropertySynchronizer angle interpolation TAU wrap-around fix

### DIFF
--- a/addons/GD-Sync/Scripts/Types/PropertySynchronizer.gd
+++ b/addons/GD-Sync/Scripts/Types/PropertySynchronizer.gd
@@ -304,7 +304,7 @@ func _interpolate(delta : float) -> void:
 			
 			node.scale = scale
 			value_changed.emit(property_name, lerped_value)
-		elif "rotation" in property_name and property_data["Type"] in [TYPE_VECTOR2, TYPE_VECTOR3]:
+		elif "rotation" in property_name.to_lower() and property_data["Type"] in [TYPE_VECTOR2, TYPE_VECTOR3]:
 			var weight := delta*interpolation_speed
 			var lerped_value: Vector3
 			lerped_value.x = lerp_angle(current_value.x, target_value.x, weight)

--- a/addons/GD-Sync/Scripts/Types/PropertySynchronizer.gd
+++ b/addons/GD-Sync/Scripts/Types/PropertySynchronizer.gd
@@ -304,6 +304,15 @@ func _interpolate(delta : float) -> void:
 			
 			node.scale = scale
 			value_changed.emit(property_name, lerped_value)
+		elif "rotation" in property_name and property_data["Type"] in [TYPE_VECTOR2, TYPE_VECTOR3]:
+			var weight := delta*interpolation_speed
+			var lerped_value: Vector3
+			lerped_value.x = lerp_angle(current_value.x, target_value.x, weight)
+			lerped_value.y = lerp_angle(current_value.y, target_value.y, weight)
+			if property_data["Type"] == TYPE_VECTOR3:
+				lerped_value.z = lerp_angle(current_value.z, target_value.z, weight)
+			node.set(property_name, lerped_value)
+			value_changed.emit(property_name, lerped_value)
 		else:
 			var lerped_value = lerp(current_value, target_value, delta*interpolation_speed)
 			node.set(property_name, lerped_value)


### PR DESCRIPTION
Hey there,

When I created issue #117 I went on to implement my proposed fix in the PropertySynchronizer and I wanted to offer it as a contribution.

In these two commits I implemented in the PropertySynchronizer checking whether the property has "rotation" in its name, and is of type Vector2 or Vector3. If yes, each X Y (and Z for Vector3) component uses the built-in lerp_angle. I've been using these changes in my game and it appears stable.

_(The purpose of the weight variable is so that the code doesn't recalculate the same thing twice)_