### PR TITLE
fix GDSync disconnecting upon pausing the game

### DIFF
--- a/addons/GD-Sync/Scripts/ConnectionController.gd
+++ b/addons/GD-Sync/Scripts/ConnectionController.gd
@@ -99,7 +99,9 @@ func _ready() -> void:
 		
 		If you are using local multiplayer only, you can ignore this error."
 		)
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func is_active() -> bool:
 	return status >= ENUMS.CONNECTION_STATUS.CONNECTING
 

--- a/addons/GD-Sync/Scripts/DataController.gd
+++ b/addons/GD-Sync/Scripts/DataController.gd
@@ -48,7 +48,9 @@ func _ready() -> void:
 		DirAccess.make_dir_absolute("user://GD-Sync")
 	
 	load_config()
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func _process(delta: float) -> void:
 	if logged_in:
 		status_ping_timer -= delta

--- a/addons/GD-Sync/Scripts/LocalServer.gd
+++ b/addons/GD-Sync/Scripts/LocalServer.gd
@@ -90,7 +90,9 @@ func _ready() -> void:
 	add_child(local_lobby_timer)
 	
 	set_process(false)
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func reset_multiplayer() -> void:
 	logger.write_log("Closing local multiplayer.", "[LocalServer]")
 	local_peer.close()

--- a/addons/GD-Sync/Scripts/Logger.gd
+++ b/addons/GD-Sync/Scripts/Logger.gd
@@ -81,7 +81,9 @@ func _ready() -> void:
 		for i in range(files.size()-4):
 			var log_time : int = keys[i]
 			DirAccess.remove_absolute(LOG_PATH+"/"+file_times[log_time])
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func _process(delta: float) -> void:
 	log_timer -= delta
 	_process_logs()

--- a/addons/GD-Sync/Scripts/SessionController.gd
+++ b/addons/GD-Sync/Scripts/SessionController.gd
@@ -88,7 +88,9 @@ func _ready() -> void:
 	
 	randomize()
 	synced_time = randf_range(0, 1000)
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func _process(delta):
 	if !GDSync.is_active(): return
 	handle_events(delta)

--- a/addons/GD-Sync/Scripts/Steam.gd
+++ b/addons/GD-Sync/Scripts/Steam.gd
@@ -41,7 +41,9 @@ func _ready() -> void:
 	
 	steam_integration_enabled = Engine.has_singleton("Steam")
 	if steam_integration_enabled: init_steam()
-
+	
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	
 func init_steam() -> void:
 	steam = Engine.get_singleton("Steam")
 	


### PR DESCRIPTION
This commit will fix GDSync functions stopping upon game pause.
Just a simple process_mode = Node.PROCESS_MODE_ALWAYS to scripts that uses _process functions.
I hope this helps. I personally always add this manually everytime GDSync got updated